### PR TITLE
Handle multiple configuration directives that have the same name

### DIFF
--- a/src/ConfigType/Apache.php
+++ b/src/ConfigType/Apache.php
@@ -55,7 +55,19 @@ class Apache extends AbstractConfigType implements ConfigTypeInterface
                     $result = $this->append($block, $result);
                     $block = array();
                 } else {
-                    $blockChild[$configMatches[1]] = $configMatches[2];
+                    // Check if $blockChild[$configMatches[1] already exists
+                    if (isset($blockChild[$configMatches[1]])) {
+                        // Check if $blockChild[$configMatches[1]] is string
+                        if (is_string($blockChild[$configMatches[1]])) {
+                            // Convert the string to an array, so it can handle multiple values
+                            $blockChild[$configMatches[1]] = [$blockChild[$configMatches[1]]];
+                        }
+                        // Add the new value to the array
+                        $blockChild[$configMatches[1]][] = $configMatches[2];
+                    } else {
+                        // $blockChild[$configMatches[1]] does not exist yet, add the new value as a string
+                        $blockChild[$configMatches[1]] = $configMatches[2];
+                    }
                 }
             }
             if (preg_match('/^\s*<(\w+)(?:\s+([^>]*)|\s*)>\s*$/', $configLine, $configMatches)) { // Section start


### PR DESCRIPTION
Fix for https://github.com/nikoutel/HelionConfig/issues/1

Multiple configuration directives with the same name will be added as an array, so they won't overwrite eachother.

See below for what it results in: (VirtualHost.Include.0 / VirtualHost.Include.1)

```
    [VirtualHost.ServerAdmin] => foot@bar.com
    [VirtualHost.ServerName] => %1.local.dev
    [VirtualHost.VirtualDocumentRoot] => /var/www/vhosts/%1/web
    [VirtualHost.RewriteEngine] => On
    [VirtualHost.RewriteRule] => (.*) https://%{HTTP_HOST}%{REQUEST_URI}
    [VirtualHost.CustomLog] => ${APACHE_LOG_DIR}/access.log vhost_combined
    [VirtualHost.Include.0] => conf-available/php7.2-fpm.conf
    [VirtualHost.Include.1] => conf-available/php7.3-fpm.conf
    [VirtualHost.@attribute] => *:80
```
