### PR TITLE
Change apache regex to handle config directives without parameters

### DIFF
--- a/src/ConfigType/Apache.php
+++ b/src/ConfigType/Apache.php
@@ -46,7 +46,7 @@ class Apache extends AbstractConfigType implements ConfigTypeInterface
                 $configLine = $previousLine . trim($configLine);
                 $previousLine = '';
             }
-            if (preg_match('/^\s*(\w+)(?:\s+(.*?)|)\s*$/', $configLine, $configMatches)) { // Property
+            if (preg_match('/^\s*(\w+)(?:\s*(.*?)|)\s*$/', $configLine, $configMatches)) { // Property
                 if (!isset($configMatches[2])) {
                     throw new \UnexpectedValueException("Apache config format error!");
                 }

--- a/src/ConfigType/Apache.php
+++ b/src/ConfigType/Apache.php
@@ -55,7 +55,19 @@ class Apache extends AbstractConfigType implements ConfigTypeInterface
                     $result = $this->append($block, $result);
                     $block = array();
                 } else {
-                    $blockChild[$configMatches[1]] = $configMatches[2];
+                    // Check if $blockChild[$configMatches[1] already exists
+                    if (isset($blockChild[$configMatches[1]])) {
+                        // Check if $blockChild[$configMatches[1]] is string
+                        if (is_string($blockChild[$configMatches[1]])) {
+                            // Convert the string to an array, so it can handle multiple values
+                            $blockChild[$configMatches[1]] = [$blockChild[$configMatches[1]]];
+                        }
+                        // Add the new value to the array
+                        $blockChild[$configMatches[1]][] = $configMatches[2];
+                    } else {
+                        // $blockChild[$configMatches[1]] does not exist yet, add the new value as a string
+                        $blockChild[$configMatches[1]] = $configMatches[2];
+                    }
                 }
             }
             if (preg_match('/^\s*<(\w+)(?:\s+([^>]*)|\s*)>\s*$/', $configLine, $configMatches)) { // Section start

--- a/src/ConfigType/Apache.php
+++ b/src/ConfigType/Apache.php
@@ -55,19 +55,7 @@ class Apache extends AbstractConfigType implements ConfigTypeInterface
                     $result = $this->append($block, $result);
                     $block = array();
                 } else {
-                    // Check if $blockChild[$configMatches[1] already exists
-                    if (isset($blockChild[$configMatches[1]])) {
-                        // Check if $blockChild[$configMatches[1]] is string
-                        if (is_string($blockChild[$configMatches[1]])) {
-                            // Convert the string to an array, so it can handle multiple values
-                            $blockChild[$configMatches[1]] = [$blockChild[$configMatches[1]]];
-                        }
-                        // Add the new value to the array
-                        $blockChild[$configMatches[1]][] = $configMatches[2];
-                    } else {
-                        // $blockChild[$configMatches[1]] does not exist yet, add the new value as a string
-                        $blockChild[$configMatches[1]] = $configMatches[2];
-                    }
+                    $blockChild[$configMatches[1]] = $configMatches[2];
                 }
             }
             if (preg_match('/^\s*<(\w+)(?:\s+([^>]*)|\s*)>\s*$/', $configLine, $configMatches)) { // Section start


### PR DESCRIPTION
Fix for: https://github.com/nikoutel/HelionConfig/issues/3

Basically it changes the regex to to 0 or more whitespaces after the directive instead of 1 or more. 